### PR TITLE
Implement receipt analysis workflow

### DIFF
--- a/courierktv/app/app/api/receipts/analyze/route.ts
+++ b/courierktv/app/app/api/receipts/analyze/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { analyzeReceiptText } from '@/lib/receipt-parser';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const textField = formData.get('text');
+    const file = formData.get('file') as File | null;
+
+    let rawText = typeof textField === 'string' ? textField : '';
+
+    if (!rawText && file) {
+      const mime = file.type || '';
+      if (mime.startsWith('text/') || file.name.toLowerCase().endsWith('.txt')) {
+        rawText = await file.text();
+      }
+    }
+
+    rawText = rawText.replace(/\u0000/g, ' ').trim();
+
+    if (!rawText) {
+      return NextResponse.json(
+        {
+          message:
+            'Не удалось распознать текст чека. Добавьте текст вручную и попробуйте снова.',
+        },
+        { status: 400 }
+      );
+    }
+
+    const analysis = analyzeReceiptText(rawText);
+
+    return NextResponse.json({
+      ...analysis,
+      fileName: file?.name ?? null,
+      mimeType: file?.type ?? null,
+      source: typeof textField === 'string' && textField.trim().length > 0 ? 'text' : 'file',
+    });
+  } catch (error) {
+    console.error('Receipt analysis error:', error);
+    return NextResponse.json(
+      { message: 'Не удалось обработать чек. Попробуйте еще раз.' },
+      { status: 500 }
+    );
+  }
+}

--- a/courierktv/app/app/api/receipts/route.ts
+++ b/courierktv/app/app/api/receipts/route.ts
@@ -1,9 +1,11 @@
 
 import { NextRequest, NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
-import { parsePhoneNumber, getZoneByAddress, extractAddressComponents, detectHandwrittenSum } from '@/lib/utils';
+import { parsePhoneNumber, getZoneByAddress, extractAddressComponents } from '@/lib/utils';
 
 export const dynamic = 'force-dynamic';
 
@@ -46,7 +48,16 @@ export async function POST(request: NextRequest) {
     }
 
     const formData = await request.formData();
-    const dataString = formData.get('data') as string;
+    const dataString = formData.get('data') as string | null;
+    const imageFile = formData.get('image') as File | null;
+
+    if (!dataString) {
+      return NextResponse.json(
+        { message: 'Не переданы данные чека' },
+        { status: 400 }
+      );
+    }
+
     const data = JSON.parse(dataString);
 
     const {
@@ -58,11 +69,33 @@ export async function POST(request: NextRequest) {
       hasHandwrittenSum,
     } = data;
 
-    if (!fullAddress || !totalAmount || !paymentMethod) {
+    const numericAmount = typeof totalAmount === 'string' ? parseFloat(totalAmount) : totalAmount;
+
+    if (!fullAddress || numericAmount === null || Number.isNaN(numericAmount) || !paymentMethod) {
       return NextResponse.json(
         { message: 'Заполните все обязательные поля' },
         { status: 400 }
       );
+    }
+
+    let imageUrl: string | null = null;
+    let originalFileName: string | null = null;
+
+    if (imageFile && imageFile.size > 0) {
+      const arrayBuffer = await imageFile.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const uploadDir = path.join(process.cwd(), 'public', 'uploads', 'receipts');
+      await fs.mkdir(uploadDir, { recursive: true });
+
+      const sanitizedName = imageFile.name
+        .replace(/[^A-Za-z0-9._-]/g, '_')
+        .slice(-80);
+      const fileName = `${Date.now()}-${sanitizedName || 'receipt'}`;
+      const filePath = path.join(uploadDir, fileName);
+      await fs.writeFile(filePath, buffer);
+
+      imageUrl = `/uploads/receipts/${fileName}`;
+      originalFileName = imageFile.name;
     }
 
     // Parse phone number
@@ -106,12 +139,14 @@ export async function POST(request: NextRequest) {
         apartment: addressComponents.apartment,
         phoneNumber: phoneData.main,
         additionalNumber: phoneData.additional,
-        totalAmount,
+        totalAmount: numericAmount,
         paymentMethod,
         hasHandwrittenSum: hasHandwrittenSum || false,
         zoneRate,
         earnings,
         status: 'processed',
+        imageUrl,
+        originalFileName,
       },
       include: {
         zone: true,

--- a/courierktv/app/components/receipt-processor.tsx
+++ b/courierktv/app/components/receipt-processor.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import { useState, useCallback } from 'react';
@@ -23,14 +22,33 @@ import {
   CreditCard,
   Smartphone,
   Building2,
+  Sparkles,
+  Lightbulb,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import Image from 'next/image';
+import type { ReceiptAnalysisSource, ReceiptDetectedFields } from '@/lib/types';
 
 interface ReceiptProcessorProps {
   onClose: () => void;
   onReceiptProcessed: () => void;
 }
+
+const createInitialDetectedFields = (): ReceiptDetectedFields => ({
+  restaurant: false,
+  fullAddress: false,
+  phoneNumber: false,
+  totalAmount: false,
+  paymentMethod: false,
+});
+
+const DETECTED_FIELD_LABELS: Record<keyof ReceiptDetectedFields, string> = {
+  restaurant: 'Ресторан',
+  fullAddress: 'Адрес',
+  phoneNumber: 'Телефон',
+  totalAmount: 'Сумма',
+  paymentMethod: 'Оплата',
+};
 
 export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcessorProps) {
   const [step, setStep] = useState<'upload' | 'processing' | 'edit'>('upload');
@@ -38,6 +56,14 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
   const [previewUrl, setPreviewUrl] = useState<string>('');
   const [loading, setLoading] = useState(false);
   const [hasHandwrittenSum, setHasHandwrittenSum] = useState(false);
+  const [rawText, setRawText] = useState('');
+  const [analysisWarnings, setAnalysisWarnings] = useState<string[]>([]);
+  const [analysisSuggestions, setAnalysisSuggestions] = useState<string[]>([]);
+  const [analysisConfidence, setAnalysisConfidence] = useState<number | null>(null);
+  const [analysisSource, setAnalysisSource] = useState<ReceiptAnalysisSource | null>(null);
+  const [detectedFields, setDetectedFields] = useState<ReceiptDetectedFields>(() =>
+    createInitialDetectedFields()
+  );
   const [formData, setFormData] = useState({
     restaurant: '',
     fullAddress: '',
@@ -46,68 +72,177 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
     paymentMethod: '',
   });
 
-  const onDrop = useCallback((acceptedFiles: File[]) => {
-    if (acceptedFiles.length > 0) {
+  const processReceipt = useCallback(
+    async ({ file, text }: { file?: File; text?: string }) => {
+      if (!file && !text) {
+        toast.error('Загрузите чек или добавьте текст для распознавания');
+        return;
+      }
+
+      setAnalysisWarnings([]);
+      setAnalysisSuggestions([]);
+      setAnalysisConfidence(null);
+      setAnalysisSource(null);
+      setDetectedFields(createInitialDetectedFields());
+      setHasHandwrittenSum(false);
+      setRawText(text ?? '');
+      setStep('processing');
+      setLoading(true);
+
+      try {
+        const formDataToSend = new FormData();
+        if (file) {
+          formDataToSend.append('file', file);
+        }
+        if (text) {
+          formDataToSend.append('text', text);
+        }
+
+        const response = await fetch('/api/receipts/analyze', {
+          method: 'POST',
+          body: formDataToSend,
+        });
+
+        if (!response.ok) {
+          const error = await response.json().catch(() => null);
+          const message = error?.message || 'Не удалось обработать чек. Заполните данные вручную.';
+          toast.error(message);
+          setAnalysisWarnings([message]);
+          setStep('edit');
+          return;
+        }
+
+        const result = await response.json();
+        const composedPhone = result.phoneNumber
+          ? result.additionalNumber
+            ? `${result.phoneNumber},${result.additionalNumber}`
+            : result.phoneNumber
+          : '';
+
+        setFormData({
+          restaurant: result.restaurant || '',
+          fullAddress: result.fullAddress || '',
+          phoneNumber: composedPhone,
+          totalAmount: result.totalAmount ? String(result.totalAmount) : '',
+          paymentMethod: result.paymentMethod || '',
+        });
+        setHasHandwrittenSum(Boolean(result.hasHandwrittenSum));
+        setRawText(result.rawText || text || '');
+        setAnalysisWarnings(Array.isArray(result.warnings) ? result.warnings : []);
+        setAnalysisSuggestions(Array.isArray(result.suggestions) ? result.suggestions : []);
+        setAnalysisConfidence(
+          typeof result.confidence === 'number'
+            ? Math.min(1, Math.max(0, result.confidence))
+            : null
+        );
+        setAnalysisSource(result.source ?? (file ? 'file' : text ? 'text' : null));
+        setDetectedFields(
+          result.detectedFields
+            ? {
+                restaurant: Boolean(result.detectedFields.restaurant),
+                fullAddress: Boolean(result.detectedFields.fullAddress),
+                phoneNumber: Boolean(result.detectedFields.phoneNumber),
+                totalAmount: Boolean(result.detectedFields.totalAmount),
+                paymentMethod: Boolean(result.detectedFields.paymentMethod),
+              }
+            : createInitialDetectedFields()
+        );
+        setStep('edit');
+      } catch (error) {
+        console.error('Receipt analysis error:', error);
+        toast.error('Ошибка обработки чека. Попробуйте еще раз');
+        setStep('edit');
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      if (acceptedFiles.length === 0) {
+        return;
+      }
+
       const file = acceptedFiles[0];
       if (file.size > 5 * 1024 * 1024) {
         toast.error('Файл слишком большой. Максимальный размер 5МБ');
         return;
       }
-      
+
       setUploadedFile(file);
-      const url = URL.createObjectURL(file);
-      setPreviewUrl(url);
-      processReceipt(file);
-    }
-  }, []);
+
+      if (file.type.startsWith('image/')) {
+        const url = URL.createObjectURL(file);
+        setPreviewUrl(url);
+      } else {
+        setPreviewUrl('');
+      }
+
+      processReceipt({ file });
+    },
+    [processReceipt]
+  );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: {
-      'image/*': ['.png', '.jpg', '.jpeg'],
+      'image/*': ['.png', '.jpg', '.jpeg', '.webp'],
+      'text/plain': ['.txt'],
     },
     maxFiles: 1,
     maxSize: 5 * 1024 * 1024,
   });
 
-  const processReceipt = async (file: File) => {
-    setStep('processing');
-    setLoading(true);
-
-    try {
-      // Simulate OCR processing
-      await new Promise(resolve => setTimeout(resolve, 2000));
-
-      // Mock extracted data with some Russian examples
-      const mockData = {
-        restaurant: 'Суши Мастер',
-        fullAddress: 'ул. Мичурина, 22, кв. 15',
-        phoneNumber: '+79610062477,44660',
-        totalAmount: '1250',
-        paymentMethod: 'cash',
-        hasHandwrittenSum: Math.random() > 0.7, // 30% chance of handwritten sum
-      };
-
-      setFormData(mockData);
-      setHasHandwrittenSum(mockData.hasHandwrittenSum);
-      setStep('edit');
-    } catch (error) {
-      toast.error('Ошибка обработки чека. Попробуйте еще раз');
-      setStep('upload');
-    } finally {
-      setLoading(false);
+  const handleRetryProcessing = () => {
+    if (rawText.trim()) {
+      processReceipt({ text: rawText });
+    } else if (uploadedFile) {
+      processReceipt({ file: uploadedFile });
+    } else {
+      toast.error('Добавьте файл чека или вставьте текст для распознавания');
     }
   };
 
-  const handleRetryProcessing = () => {
-    if (uploadedFile) {
-      processReceipt(uploadedFile);
+  const handleManualMode = () => {
+    setUploadedFile(null);
+    setPreviewUrl('');
+    setRawText('');
+    setFormData({
+      restaurant: '',
+      fullAddress: '',
+      phoneNumber: '',
+      totalAmount: '',
+      paymentMethod: '',
+    });
+    setAnalysisWarnings([]);
+    setAnalysisSuggestions([]);
+    setAnalysisConfidence(null);
+    setAnalysisSource(null);
+    setDetectedFields(createInitialDetectedFields());
+    setHasHandwrittenSum(false);
+    setStep('edit');
+  };
+
+  const handleReanalyzeText = () => {
+    if (!rawText.trim()) {
+      toast.error('Добавьте текст чека перед повторным распознаванием');
+      return;
     }
+
+    processReceipt({ text: rawText });
   };
 
   const handleSave = async () => {
     if (!formData.fullAddress || !formData.totalAmount || !formData.paymentMethod) {
       toast.error('Заполните все обязательные поля');
+      return;
+    }
+
+    const parsedAmount = Number.parseFloat(formData.totalAmount);
+    if (Number.isNaN(parsedAmount)) {
+      toast.error('Сумма заказа указана некорректно');
       return;
     }
 
@@ -117,11 +252,14 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
       if (uploadedFile) {
         formDataToSend.append('image', uploadedFile);
       }
-      formDataToSend.append('data', JSON.stringify({
-        ...formData,
-        totalAmount: parseFloat(formData.totalAmount),
-        hasHandwrittenSum,
-      }));
+      formDataToSend.append(
+        'data',
+        JSON.stringify({
+          ...formData,
+          totalAmount: parsedAmount,
+          hasHandwrittenSum,
+        })
+      );
 
       const response = await fetch('/api/receipts', {
         method: 'POST',
@@ -132,8 +270,8 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
         toast.success('Чек успешно сохранен!');
         onReceiptProcessed();
       } else {
-        const error = await response.json();
-        toast.error(error.message || 'Ошибка сохранения чека');
+        const error = await response.json().catch(() => null);
+        toast.error(error?.message || 'Ошибка сохранения чека');
       }
     } catch (error) {
       toast.error('Произошла ошибка. Попробуйте еще раз');
@@ -148,6 +286,12 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
     { value: 'transfer', label: 'Перевод', icon: Smartphone, color: 'text-purple-500' },
     { value: 'terminal', label: 'Терминал', icon: Building2, color: 'text-orange-500' },
   ];
+
+  const hasAnalysis =
+    analysisConfidence !== null ||
+    analysisWarnings.length > 0 ||
+    analysisSuggestions.length > 0 ||
+    Object.values(detectedFields).some(Boolean);
 
   return (
     <div className="fixed inset-0 bg-background z-50 overflow-y-auto">
@@ -175,16 +319,16 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
                 className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
                   isDragActive
                     ? 'border-primary bg-primary/10'
-                    : 'border-muted-foreground hover:border-primary'
+                    : 'border-muted-foreground/40 hover:border-primary'
                 }`}
               >
                 <input {...getInputProps()} />
                 <Upload className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
                 <h3 className="text-lg font-semibold mb-2">
-                  {isDragActive ? 'Отпустите файл здесь' : 'Загрузите фото чека'}
+                  {isDragActive ? 'Отпустите файл здесь' : 'Загрузите чек или текстовый файл'}
                 </h3>
                 <p className="text-muted-foreground mb-4">
-                  Перетащите изображение или нажмите для выбора
+                  Перетащите изображение или текстовый файл чека, либо нажмите для выбора
                 </p>
                 <div className="flex items-center justify-center gap-4">
                   <Button variant="outline" size="sm">
@@ -197,8 +341,13 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
                   </Button>
                 </div>
                 <p className="text-xs text-muted-foreground mt-4">
-                  Поддерживаются JPG, PNG (до 5МБ)
+                  Поддерживаются JPG, PNG и TXT (до 5&nbsp;МБ)
                 </p>
+              </div>
+              <div className="mt-4 text-center">
+                <Button variant="ghost" size="sm" onClick={handleManualMode}>
+                  Заполнить данные вручную
+                </Button>
               </div>
             </CardContent>
           </Card>
@@ -209,9 +358,9 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
           <Card>
             <CardContent className="p-8 text-center">
               <Loader2 className="h-12 w-12 mx-auto mb-4 animate-spin text-primary" />
-              <h3 className="text-lg font-semibold mb-2">Обрабатываем чек...</h3>
+              <h3 className="text-lg font-semibold mb-2">Анализируем чек...</h3>
               <p className="text-muted-foreground">
-                Извлекаем данные с помощью ИИ. Это займет несколько секунд.
+                Извлекаем адрес, сумму и контакты. Обычно это занимает не более пары секунд.
               </p>
             </CardContent>
           </Card>
@@ -239,15 +388,102 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
               </Card>
             )}
 
-            {/* Warnings */}
-            {hasHandwrittenSum && (
-              <Alert>
-                <AlertTriangle className="h-4 w-4" />
-                <AlertDescription>
-                  Обнаружена рукописная сумма. Пожалуйста, проверьте корректность распознавания.
-                </AlertDescription>
-              </Alert>
+            {/* Analysis summary */}
+            {hasAnalysis && (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Результаты распознавания</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {analysisConfidence !== null && (
+                      <Badge variant="outline" className="bg-primary/10 border-primary/30 text-primary">
+                        Точность распознавания: {Math.round(analysisConfidence * 100)}%
+                      </Badge>
+                    )}
+                    {analysisSource && (
+                      <Badge variant="outline" className="bg-muted">
+                        Источник: {analysisSource === 'file' ? 'файл' : 'текст'}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {Object.entries(DETECTED_FIELD_LABELS).map(([key, label]) => {
+                      const detected = detectedFields[key as keyof ReceiptDetectedFields];
+                      return (
+                        <Badge
+                          key={key}
+                          variant={detected ? 'default' : 'outline'}
+                          className={detected ? '' : 'text-muted-foreground'}
+                        >
+                          {label}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                  {analysisWarnings.map((warning, index) => (
+                    <Alert
+                      key={`${warning}-${index}`}
+                      className="border-amber-200 bg-amber-50 text-amber-900"
+                    >
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertDescription>{warning}</AlertDescription>
+                    </Alert>
+                  ))}
+                  {analysisSuggestions.length > 0 && (
+                    <div className="space-y-2">
+                      {analysisSuggestions.map((suggestion, index) => (
+                        <div
+                          key={`${suggestion}-${index}`}
+                          className="flex items-center gap-2 text-sm text-muted-foreground"
+                        >
+                          <Lightbulb className="h-4 w-4 text-amber-500" />
+                          <span>{suggestion}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {hasHandwrittenSum && !analysisWarnings.some((warning) => warning.includes('рукопис')) && (
+                    <Alert className="border-amber-200 bg-amber-50 text-amber-900">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertDescription>
+                        Обнаружена рукописная сумма. Пожалуйста, проверьте корректность распознавания.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </CardContent>
+              </Card>
             )}
+
+            {/* Recognized text */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>Распознанный текст</span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleReanalyzeText}
+                    disabled={loading || !rawText.trim()}
+                  >
+                    <Sparkles className="mr-2 h-4 w-4" />
+                    Перераспознать текст
+                  </Button>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Textarea
+                  id="rawText"
+                  placeholder="Вставьте текст чека или отредактируйте распознанный"
+                  value={rawText}
+                  onChange={(e) => setRawText(e.target.value)}
+                  className="min-h-32 font-mono text-sm"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Если автоматическое распознавание сработало неверно, отредактируйте текст и попробуйте снова.
+                </p>
+              </CardContent>
+            </Card>
 
             {/* Form */}
             <Card>
@@ -300,7 +536,7 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
                   </p>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="space-y-2">
                     <Label htmlFor="amount">Сумма заказа *</Label>
                     <Input
@@ -348,12 +584,14 @@ export function ReceiptProcessor({ onClose, onReceiptProcessed }: ReceiptProcess
                       return (
                         <Button
                           key={method.value}
-                          variant={isSelected ? "default" : "outline"}
+                          variant={isSelected ? 'default' : 'outline'}
                           size="sm"
                           onClick={() => setFormData({ ...formData, paymentMethod: method.value })}
                           className="justify-start"
                         >
-                          <Icon className={`mr-2 h-4 w-4 ${isSelected ? 'text-white' : method.color}`} />
+                          <Icon
+                            className={`mr-2 h-4 w-4 ${isSelected ? 'text-white' : method.color}`}
+                          />
                           {method.label}
                         </Button>
                       );

--- a/courierktv/app/lib/receipt-parser.ts
+++ b/courierktv/app/lib/receipt-parser.ts
@@ -1,0 +1,373 @@
+import { detectHandwrittenSum } from '@/lib/utils';
+import type {
+  ReceiptAnalysisResult,
+  ReceiptDetectedFields,
+} from '@/lib/types';
+
+const ADDRESS_KEYWORDS = [
+  'ул',
+  'улица',
+  'пр',
+  'пр-т',
+  'просп',
+  'проспект',
+  'дом',
+  'д.',
+  'корп',
+  'к.',
+  'строение',
+  'стр.',
+  'лит',
+  'мкр',
+  'микрорайон',
+  'кв',
+  'квартира',
+  'офис',
+  'подъезд',
+  'этаж',
+  'город',
+  'г.',
+  'пос',
+  'посёлок',
+];
+
+const RESTAURANT_STOP_WORDS = [
+  'кассов',
+  'фиск',
+  'покуп',
+  'оплат',
+  'адрес',
+  'тел',
+  'инн',
+  'огрн',
+  'чек',
+  'смена',
+  'пробит',
+  'поставщик',
+  'пользовател',
+  'дата',
+  'время',
+  'сайт',
+  'состав',
+  'операц',
+  'сумма',
+  'итог',
+  'итого',
+];
+
+const PAYMENT_KEYWORDS: Record<string, RegExp[]> = {
+  cash: [
+    /налич/i,
+    /нал\.?/i,
+    /оплата\s+курьеру/i,
+    /выдать\s+сдачу/i,
+    /оплатил\s+налом/i,
+  ],
+  card: [
+    /карта/i,
+    /банковск.*кар/i,
+    /оплачено\s+картой/i,
+    /безнал/i,
+    /visa/i,
+    /mastercard/i,
+    /mir/i,
+  ],
+  transfer: [
+    /перевод/i,
+    /сбербанк\s*онлайн/i,
+    /sbp/i,
+    /быстрых\s+платежей/i,
+    /по\s+номеру\s+тел/i,
+    /по\s+реквизитам/i,
+  ],
+  terminal: [
+    /терминал/i,
+    /pos/i,
+    /пин.?пад/i,
+    /эквайр/i,
+  ],
+};
+
+const FIELD_LABELS: Array<keyof ReceiptDetectedFields> = [
+  'restaurant',
+  'fullAddress',
+  'phoneNumber',
+  'totalAmount',
+  'paymentMethod',
+];
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function cleanupLine(line: string): string {
+  return line.replace(/[«»"'`]/g, '').trim();
+}
+
+function toNumber(value: string): number | null {
+  const normalized = value.replace(/\s+/g, '').replace(',', '.');
+  const parsed = parseFloat(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function extractRestaurant(lines: string[]): string {
+  for (const line of lines) {
+    if (line.length < 2 || line.length > 60) {
+      continue;
+    }
+
+    if (!/[A-Za-zА-Яа-я]/.test(line)) {
+      continue;
+    }
+
+    if (/\d{4,}/.test(line)) {
+      continue;
+    }
+
+    const lower = line.toLowerCase();
+    if (RESTAURANT_STOP_WORDS.some((word) => lower.includes(word))) {
+      continue;
+    }
+
+    // Avoid picking addresses as restaurant names
+    if (ADDRESS_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      continue;
+    }
+
+    return line;
+  }
+
+  return '';
+}
+
+function extractAddress(lines: string[]): string {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lower = line.toLowerCase();
+
+    if (!ADDRESS_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      continue;
+    }
+
+    let candidate = line;
+    let nextIndex = i + 1;
+
+    while (nextIndex < lines.length) {
+      const nextLine = lines[nextIndex];
+      const nextLower = nextLine.toLowerCase();
+      if (/^(дом|д\.|корп|к\.|стр\.|строение|лит|литера|кв|квартира|офис|подъезд|этаж|мкр|микрорайон|пос|пос\.)/.test(nextLower)) {
+        candidate = `${candidate}, ${nextLine}`;
+        nextIndex++;
+      } else {
+        break;
+      }
+    }
+
+    return candidate;
+  }
+
+  return '';
+}
+
+function extractPhone(text: string): { phoneNumber: string; additionalNumber?: string } {
+  const normalized = text.replace(/\u0000/g, ' ').replace(/\s+/g, ' ');
+  const regex = /(\+?7|8)(?:[\s-]*\(?\d{3}\)?[\s-]*)\d{3}[\s-]*\d{2}[\s-]*\d{2}(?:[,\s-]*(?:доб\.?|ext\.?|#)?\s*(\d{2,6}))?/i;
+  const match = normalized.match(regex);
+
+  if (!match) {
+    return { phoneNumber: '' };
+  }
+
+  let raw = match[0];
+  let additional: string | undefined = undefined;
+
+  if (raw.includes(',')) {
+    const parts = raw.split(',');
+    raw = parts[0];
+    if (parts[1]) {
+      additional = parts[1].replace(/[^\d]/g, '');
+    }
+  }
+
+  if (match[2] && !additional) {
+    additional = match[2].replace(/[^\d]/g, '');
+  }
+
+  let digits = raw.replace(/[^\d]/g, '');
+
+  if (digits.length === 11 && digits.startsWith('8')) {
+    digits = `7${digits.slice(1)}`;
+  }
+
+  if (digits.length === 11 && digits.startsWith('7')) {
+    return {
+      phoneNumber: `+${digits}`,
+      additionalNumber: additional,
+    };
+  }
+
+  if (digits.length === 10) {
+    return {
+      phoneNumber: `+7${digits}`,
+      additionalNumber: additional,
+    };
+  }
+
+  return {
+    phoneNumber: digits ? `+${digits}` : '',
+    additionalNumber: additional,
+  };
+}
+
+function extractTotalAmount(lines: string[]): number | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const keywordMatch = line.match(/(итог|итого|к\s*оплате|всего|сумма|total|amount)[^\d]*([\d\s]+[\d.,]*)/i);
+    if (keywordMatch) {
+      const value = toNumber(keywordMatch[2]);
+      if (value !== null) {
+        return value;
+      }
+    }
+
+    const currencyMatch = line.match(/([\d\s]+[\d.,]*)\s*(?:руб|р\.?|rub|₽)/i);
+    if (currencyMatch) {
+      const value = toNumber(currencyMatch[1]);
+      if (value !== null) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function detectPaymentMethod(text: string): string {
+  const normalized = text.toLowerCase();
+  const scores: Record<string, number> = {
+    cash: 0,
+    card: 0,
+    transfer: 0,
+    terminal: 0,
+  };
+
+  for (const [method, patterns] of Object.entries(PAYMENT_KEYWORDS)) {
+    for (const pattern of patterns) {
+      if (pattern.test(normalized)) {
+        scores[method] += 1;
+      }
+    }
+  }
+
+  // Terminal usually implies card payment as well
+  if (scores.terminal > 0) {
+    scores.card += 0.5;
+  }
+
+  const sorted = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+  const [method, value] = sorted[0];
+
+  return value > 0 ? method : '';
+}
+
+function extractDate(text: string): string | undefined {
+  const match = text.match(/(\d{2}[.\/-]\d{2}[.\/-]\d{2,4})/);
+  if (!match) {
+    return undefined;
+  }
+
+  const [day, month, year] = match[1].split(/[.\/-]/);
+  if (!day || !month || !year) {
+    return undefined;
+  }
+
+  const normalizedYear = year.length === 2 ? `20${year}` : year;
+
+  return `${normalizedYear}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
+function extractTime(text: string): string | undefined {
+  const match = text.match(/(\d{2}:\d{2}(?::\d{2})?)/);
+  return match ? match[1] : undefined;
+}
+
+export function analyzeReceiptText(rawText: string): ReceiptAnalysisResult {
+  const sanitized = rawText.replace(/\r/g, '\n');
+  const lines = sanitized
+    .split(/\n+/)
+    .map((line) => cleanupLine(line))
+    .filter(Boolean);
+
+  const restaurant = extractRestaurant(lines);
+  const fullAddress = extractAddress(lines);
+  const phoneData = extractPhone(sanitized);
+  const totalAmount = extractTotalAmount(lines);
+  const paymentMethod = detectPaymentMethod(sanitized);
+  const orderDate = extractDate(sanitized);
+  const orderTime = extractTime(sanitized);
+  const hasHandwrittenSum = detectHandwrittenSum(sanitized);
+
+  const detectedFields: ReceiptDetectedFields = {
+    restaurant: Boolean(restaurant),
+    fullAddress: Boolean(fullAddress),
+    phoneNumber: Boolean(phoneData.phoneNumber),
+    totalAmount: totalAmount !== null,
+    paymentMethod: Boolean(paymentMethod),
+  };
+
+  const warnings: string[] = [];
+
+  if (!fullAddress) {
+    warnings.push('Не удалось определить адрес доставки. Проверьте поле вручную.');
+  }
+
+  if (!phoneData.phoneNumber) {
+    warnings.push('Номер телефона клиента не найден. Добавьте его вручную.');
+  }
+
+  if (totalAmount === null) {
+    warnings.push('Сумма заказа не распознана автоматически. Укажите сумму вручную.');
+  }
+
+  if (!paymentMethod) {
+    warnings.push('Способ оплаты не найден в тексте чека. Выберите подходящий вариант.');
+  }
+
+  if (hasHandwrittenSum) {
+    warnings.push('Обнаружены признаки рукописной суммы. Проверьте корректность данных.');
+  }
+
+  const suggestions: string[] = [];
+
+  if (phoneData.additionalNumber) {
+    suggestions.push('Добавочный номер был найден в чеке и добавлен автоматически.');
+  }
+
+  if (orderDate) {
+    suggestions.push(`Дата заказа распознана как ${orderDate.split('-').reverse().join('.')}.`);
+  }
+
+  if (orderTime) {
+    suggestions.push(`Время заказа распознано как ${orderTime}.`);
+  }
+
+  const confidence = FIELD_LABELS.reduce((acc, field) => acc + (detectedFields[field] ? 1 : 0), 0) /
+    FIELD_LABELS.length;
+
+  return {
+    restaurant,
+    fullAddress,
+    phoneNumber: phoneData.phoneNumber,
+    additionalNumber: phoneData.additionalNumber,
+    totalAmount,
+    paymentMethod,
+    hasHandwrittenSum,
+    orderDate,
+    orderTime,
+    rawText: normalizeWhitespace(sanitized),
+    warnings,
+    suggestions,
+    confidence,
+    detectedFields,
+  };
+}

--- a/courierktv/app/lib/types.ts
+++ b/courierktv/app/lib/types.ts
@@ -142,3 +142,30 @@ export interface ZoneSearchResult {
   zone: Zone | null;
   city: City | null;
 }
+
+export type ReceiptAnalysisSource = 'file' | 'text';
+
+export interface ReceiptDetectedFields {
+  restaurant: boolean;
+  fullAddress: boolean;
+  phoneNumber: boolean;
+  totalAmount: boolean;
+  paymentMethod: boolean;
+}
+
+export interface ReceiptAnalysisResult {
+  restaurant: string;
+  fullAddress: string;
+  phoneNumber: string;
+  additionalNumber?: string;
+  totalAmount: number | null;
+  paymentMethod: string;
+  hasHandwrittenSum: boolean;
+  orderDate?: string;
+  orderTime?: string;
+  rawText: string;
+  warnings: string[];
+  suggestions: string[];
+  confidence: number;
+  detectedFields: ReceiptDetectedFields;
+}


### PR DESCRIPTION
## Summary
- add a text-first receipt parser and expose it through a dedicated `/api/receipts/analyze` endpoint for automatic field extraction
- redesign the receipt processor UI to drive the new analysis flow, let couriers edit recognized text, and surface confidence, warnings, and manual reprocessing controls
- persist uploaded receipt images alongside parsed data and extend shared types so downstream features can reuse analysis metadata

## Testing
- npm install *(fails: 403 Forbidden when downloading packages from registry)*
- npm run lint *(fails: `next` binary not available because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2771ec108323b225810f0718ab17