### PR TITLE
Add placeholder homepage for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>courierktv.ru — сайт в разработке</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: radial-gradient(circle at top left, #f0f4ff, #d9e4ff);
+      color: #111827;
+      text-align: center;
+      padding: 2rem;
+    }
+
+    .card {
+      background: rgba(255, 255, 255, 0.85);
+      backdrop-filter: blur(8px);
+      border-radius: 18px;
+      padding: 3rem 2.5rem;
+      max-width: 480px;
+      box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+    }
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2rem, 5vw, 2.8rem);
+      color: #1d4ed8;
+    }
+
+    p {
+      margin: 0 0 1.5rem;
+      line-height: 1.6;
+    }
+
+    .muted {
+      color: #6b7280;
+      font-size: 0.95rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: radial-gradient(circle at top left, #0f172a, #1e293b);
+        color: #f8fafc;
+      }
+
+      .card {
+        background: rgba(30, 41, 59, 0.75);
+        box-shadow: 0 20px 60px rgba(2, 6, 23, 0.6);
+      }
+
+      h1 {
+        color: #60a5fa;
+      }
+
+      .muted {
+        color: #94a3b8;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Сайт работает! 🎉</h1>
+    <p>Это временная главная страница <strong>courierktv.ru</strong>.</p>
+    <p class="muted">Содержимое проекта пока в разработке. Обновите страницу позже — мы обязательно подготовим полноценный сайт.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple static `index.html` placeholder so GitHub Pages serves content from the repository root

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cec24ade788323b59aa1e1e008b37b