### PR TITLE
Fix recognized text parsing and auto-fill order form

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -200,22 +200,139 @@ async function sendReceipt(file) {
 }
 
 function handleServerResult(result) {
-  transcriptBox.textContent = result.normalizedText || result.text || '—';
-  if (result.data) {
-    if (result.data.address) {
-      addressInput.value = result.data.address;
-    }
-    if (result.data.amount !== null && result.data.amount !== undefined) {
-      amountInput.value = result.data.amount;
-    }
-    if (result.data.phone) {
-      phoneInput.value = formatPhone(result.data.phone);
-    }
-  }
+  const rawText = result.normalizedText || result.text || '';
+  const normalizedText = typeof rawText === 'string' ? rawText.trim() : '';
+  transcriptBox.textContent = normalizedText || '—';
+
+  const parsed = parseRecognizedText(normalizedText);
+  addressInput.value = parsed.address;
+  amountInput.value = parsed.amount;
+  phoneInput.value = parsed.phone ? formatPhone(parsed.phone) : '';
 
   updateCallAction();
   updateRouteAction();
-  renderWarnings(result.warnings || []);
+
+  const serverWarnings = Array.isArray(result.warnings) ? result.warnings : [];
+  const combinedWarnings = mergeWarnings(serverWarnings, buildParsingWarnings(parsed));
+  renderWarnings(combinedWarnings);
+}
+
+function parseRecognizedText(text) {
+  if (!text) {
+    return { address: '', amount: '', phone: '' };
+  }
+
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return { address: '', amount: '', phone: '' };
+  }
+
+  const address = extractAddressFromText(normalized);
+  const amount = extractAmountFromText(normalized);
+  const phone = extractPhoneFromText(normalized);
+
+  return {
+    address,
+    amount,
+    phone,
+  };
+}
+
+function extractAddressFromText(text) {
+  const match = text.match(/^(.+?)(?=\sсумма|\sтелефон|$)/i);
+  if (!match) {
+    return '';
+  }
+
+  let address = match[1] || '';
+  address = address.replace(/^(?:адрес|по адресу)[\s:,-]*/i, '');
+  address = cleanAddressText(address);
+  return address;
+}
+
+function extractAmountFromText(text) {
+  const compactNumbers = text.replace(/(\d)\s+(?=\d)/g, '$1');
+  const match = compactNumbers.match(/(\d{2,6})\s?(?:р|руб|₽)/i);
+  if (!match) {
+    return '';
+  }
+  return match[1].replace(/\s+/g, '');
+}
+
+function extractPhoneFromText(text) {
+  const compact = text.replace(/[\s\-()]/g, '');
+  const match = compact.match(/(\+7|8)\d{10}/);
+  if (!match) {
+    return '';
+  }
+
+  const raw = match[0];
+  return normalizePhone(raw) || '';
+}
+
+function normalizePhone(value) {
+  if (!value) {
+    return '';
+  }
+  const digits = value.replace(/\D/g, '');
+  if (!digits) {
+    return '';
+  }
+
+  let normalized = digits;
+  if (normalized.length === 11 && normalized.startsWith('8')) {
+    normalized = `7${normalized.slice(1)}`;
+  }
+  if (normalized.length === 10) {
+    normalized = `7${normalized}`;
+  }
+  if (normalized.length !== 11 || !normalized.startsWith('7')) {
+    return '';
+  }
+  return `+${normalized}`;
+}
+
+function cleanAddressText(value) {
+  if (!value) {
+    return '';
+  }
+
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ', ')
+    .replace(/,+/g, ',')
+    .replace(/^[,\.\s]+/g, '')
+    .replace(/[\s,.;:-]+$/g, '')
+    .trim();
+}
+
+function buildParsingWarnings(parsed) {
+  const warnings = [];
+  if (!parsed.address) {
+    warnings.push('Адрес не найден в тексте');
+  }
+  if (!parsed.amount) {
+    warnings.push('Сумма не найдена в тексте');
+  }
+  if (!parsed.phone) {
+    warnings.push('Телефон не найден в тексте');
+  }
+  return warnings;
+}
+
+function mergeWarnings(serverWarnings, parsingWarnings) {
+  const seen = new Set();
+  const result = [];
+
+  [...serverWarnings, ...parsingWarnings].forEach((warning) => {
+    if (!warning || seen.has(warning)) {
+      return;
+    }
+    seen.add(warning);
+    result.push(warning);
+  });
+
+  return result;
 }
 
 function renderWarnings(items) {

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -34,15 +34,33 @@
           <div class="section-title">Данные доставки</div>
           <label class="input-group">
             <span>Адрес</span>
-            <input id="address" type="text" autocomplete="street-address" placeholder="Адрес доставки" />
+            <input
+              id="address"
+              name="address"
+              type="text"
+              autocomplete="street-address"
+              placeholder="Адрес доставки"
+            />
           </label>
           <label class="input-group">
             <span>Сумма, ₽</span>
-            <input id="amount" type="number" inputmode="decimal" placeholder="0" />
+            <input
+              id="amount"
+              name="amount"
+              type="number"
+              inputmode="decimal"
+              placeholder="1500 ₽"
+            />
           </label>
           <label class="input-group">
             <span>Телефон</span>
-            <input id="phone" type="tel" autocomplete="tel" placeholder="+7" />
+            <input
+              id="phone"
+              name="phone"
+              type="tel"
+              autocomplete="tel"
+              placeholder="+7 999 123-45-67"
+            />
           </label>
         </section>
 

--- a/src/server/utils/parser.js
+++ b/src/server/utils/parser.js
@@ -1,6 +1,6 @@
-const PHONE_REGEX = /(?:\+?7|8)[\s\-()]*\d{3}[\s\-()]*\d{3}[\s\-()]*\d{2}[\s\-()]*\d{2}/g;
-const GENERIC_AMOUNT_REGEX = /(\d+[\s\d]*[\.,]?\d*)\s*(?:руб(?:лей|ля|\b)|₽|р\b)/i;
-const LABELED_AMOUNT_REGEX = /(сумма|итого|к\s*оплате|получилось|всего)[^\d]*(\d+[\s\d]*[\.,]?\d*)/i;
+const PHONE_REGEX = /(\+7|8)\d{10}/;
+const AMOUNT_REGEX = /(\d{2,6})\s?(?:р|руб|₽)/i;
+const ADDRESS_REGEX = /^(.+?)(?=\sсумма|\sтелефон|$)/i;
 
 function parseCourierText(text) {
   if (!text || typeof text !== 'string') {
@@ -14,11 +14,19 @@ function parseCourierText(text) {
   }
 
   const normalizedWhitespace = text.replace(/\s+/g, ' ').trim();
-  const lower = normalizedWhitespace.toLowerCase();
+  if (!normalizedWhitespace) {
+    return {
+      normalizedText: '',
+      address: null,
+      amount: null,
+      phone: null,
+      warnings: ['Не удалось распознать текст'],
+    };
+  }
 
   const phone = extractPhone(normalizedWhitespace);
   const amount = extractAmount(normalizedWhitespace);
-  const address = extractAddress(normalizedWhitespace, lower);
+  const address = extractAddress(normalizedWhitespace);
 
   const warnings = [];
   if (!address) {
@@ -41,97 +49,94 @@ function parseCourierText(text) {
 }
 
 function extractPhone(text) {
-  const matches = [...text.matchAll(PHONE_REGEX)];
-  if (matches.length === 0) {
+  if (!text) {
     return null;
   }
 
-  for (const match of matches) {
-    const digits = match[0].replace(/\D/g, '');
-    const normalized = normalizePhoneDigits(digits);
-    if (normalized) {
-      return normalized;
-    }
+  const compact = text.replace(/[\s\-()]/g, '');
+  const match = compact.match(PHONE_REGEX);
+  if (!match) {
+    return null;
   }
-  return null;
+
+  return normalizePhoneDigits(match[0]);
 }
 
 function normalizePhoneDigits(digits) {
   if (!digits) {
     return null;
   }
-  let cleaned = digits;
-  if (cleaned.length === 11 && cleaned.startsWith('8')) {
-    cleaned = `7${cleaned.slice(1)}`;
+  const onlyDigits = String(digits).replace(/\D/g, '');
+  if (!onlyDigits) {
+    return null;
   }
-  if (cleaned.length === 10) {
-    cleaned = `7${cleaned}`;
+
+  let normalized = onlyDigits;
+  if (normalized.length === 11 && normalized.startsWith('8')) {
+    normalized = `7${normalized.slice(1)}`;
   }
-  if (cleaned.length === 11 && cleaned.startsWith('7')) {
-    return `+7${cleaned.slice(1)}`;
+  if (normalized.length === 10) {
+    normalized = `7${normalized}`;
   }
-  return null;
+  if (normalized.length !== 11 || !normalized.startsWith('7')) {
+    return null;
+  }
+
+  return `+${normalized}`;
 }
 
 function extractAmount(text) {
-  const labeledMatch = LABELED_AMOUNT_REGEX.exec(text.toLowerCase());
-  if (labeledMatch) {
-    return toNumber(labeledMatch[2]);
-  }
-
-  const genericMatch = GENERIC_AMOUNT_REGEX.exec(text.toLowerCase());
-  if (genericMatch) {
-    return toNumber(genericMatch[1]);
-  }
-
-  const digits = text.replace(/[^0-9]/g, '');
-  if (digits.length >= 2 && digits.length <= 6) {
-    return toNumber(digits);
-  }
-
-  return null;
-}
-
-function toNumber(raw) {
-  if (!raw) {
+  if (!text) {
     return null;
   }
-  const normalized = raw.replace(/\s+/g, '').replace(',', '.');
-  const value = Number.parseFloat(normalized);
+
+  const compact = text.replace(/(\d)\s+(?=\d)/g, '$1');
+  const match = compact.match(AMOUNT_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  const numeric = match[1].replace(/\s+/g, '');
+  const value = Number.parseInt(numeric, 10);
   if (Number.isNaN(value)) {
     return null;
   }
-  return Number.isInteger(value) ? value : Number(value.toFixed(2));
+
+  return value;
 }
 
-function extractAddress(original, lower) {
-  let endIndex = original.length;
-  const sumIndex = lower.indexOf('сумм');
-  const phoneIndex = lower.indexOf('тел');
-  if (sumIndex >= 0) {
-    endIndex = Math.min(endIndex, sumIndex);
-  }
-  if (phoneIndex >= 0) {
-    endIndex = Math.min(endIndex, phoneIndex);
-  }
-
-  let startIndex = 0;
-  const addressMatch = /(?:адрес|по адресу)[:\s-]*/i.exec(original);
-  if (addressMatch) {
-    startIndex = addressMatch.index + addressMatch[0].length;
-  }
-
-  const segment = original.slice(startIndex, endIndex).trim();
-  const cleaned = segment.replace(/\s{2,}/g, ' ').replace(/[,:;\-\s]+$/, '').trim();
-
-  if (!cleaned) {
+function extractAddress(text) {
+  if (!text) {
     return null;
   }
 
-  return capitalizeFirst(cleaned);
+  const match = text.match(ADDRESS_REGEX);
+  if (!match) {
+    return null;
+  }
+
+  let address = match[1] || '';
+  address = address.replace(/^(?:адрес|по адресу)[\s:,-]*/i, '');
+  address = cleanAddress(address);
+
+  if (!address) {
+    return null;
+  }
+
+  return capitalizeWords(address);
 }
 
-function capitalizeFirst(value) {
+function cleanAddress(value) {
+  return String(value)
+    .replace(/\s+/g, ' ')
+    .replace(/\s*,\s*/g, ', ')
+    .replace(/,+/g, ',')
+    .replace(/^[,\.\s]+/g, '')
+    .replace(/[\s,.;:-]+$/g, '')
+    .trim();
+}
+
+function capitalizeWords(value) {
   if (!value) {
     return value;
   }

--- a/tests/parser.smoke.test.js
+++ b/tests/parser.smoke.test.js
@@ -27,6 +27,12 @@ function run() {
   expectEqual(fallbackParsed.amount, null, 'Amount is missing');
   expectEqual(fallbackParsed.phone, '+79185553322', 'Phone extracted from fallback');
 
+  const sampleText = 'Грибоедова 25 сумма 1500 р телефон 8 999 123 45 67';
+  const sampleParsed = parseCourierText(sampleText);
+  expectEqual(sampleParsed.address, 'Грибоедова 25', 'Sample address parsed');
+  expectEqual(sampleParsed.amount, 1500, 'Sample amount parsed');
+  expectEqual(sampleParsed.phone, '+79991234567', 'Sample phone normalized');
+
   console.log('Parser smoke tests passed');
 }
 


### PR DESCRIPTION
## Summary
- parse the recognized transcript on the client with regexes to auto-fill address, amount, and phone fields and deduplicate warnings
- align the server-side parser with the new regex-driven extraction and improved cleanup helpers
- add input names/placeholders for clarity and extend smoke tests with the reported sample text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfcc633904832382458bb53322bc19