### PR TITLE
Implement local order workflow with routing and daily summary

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -4,11 +4,34 @@ const transcriptBox = document.getElementById('transcript');
 const addressInput = document.getElementById('address');
 const amountInput = document.getElementById('amount');
 const phoneInput = document.getElementById('phone');
+const notesInput = document.getElementById('notes');
 const callButton = document.getElementById('call-button');
 const routeButton = document.getElementById('route-button');
 const warningsBox = document.getElementById('warnings');
 const receiptInput = document.getElementById('receipt-input');
 const uploadHint = document.getElementById('upload-hint');
+
+const formModeBadge = document.getElementById('form-mode');
+const saveOrderButton = document.getElementById('save-order-button');
+const resetFormButton = document.getElementById('reset-form-button');
+
+const startRouteButton = document.getElementById('start-route-button');
+const activeOrdersList = document.getElementById('active-orders-list');
+const activeOrdersEmpty = document.getElementById('active-orders-empty');
+
+const completedSummary = document.getElementById('completed-summary');
+const completedOrdersList = document.getElementById('completed-orders-list');
+const cancelledWrapper = document.getElementById('cancelled-orders-wrapper');
+const cancelledOrdersList = document.getElementById('cancelled-orders-list');
+const finishDayButton = document.getElementById('finish-day-button');
+
+const completeOverlay = document.getElementById('complete-overlay');
+const completeAddress = document.getElementById('complete-address');
+const completeMethod = document.getElementById('complete-method');
+const completeAmount = document.getElementById('complete-amount');
+const completeCancel = document.getElementById('complete-cancel');
+const completeConfirm = document.getElementById('complete-confirm');
+const completeClose = document.getElementById('complete-close');
 
 let mediaRecorder;
 let currentStream;
@@ -17,6 +40,20 @@ let cancelOnRelease = false;
 let pointerId = null;
 let cancelRequested = false;
 let isRecording = false;
+
+const STORAGE_KEY = 'courier-orders-state-v1';
+const PAYMENT_LABELS = {
+  cash: 'Наличные',
+  transfer: 'Перевод',
+  card: 'Карта',
+};
+
+let state = loadState();
+let editingOrderId = null;
+let completionOrderId = null;
+let pendingSource = 'manual';
+let pendingRawText = '';
+let latestWarnings = [];
 
 function updateStatus(message, variant = 'idle') {
   recordStatus.textContent = message;
@@ -180,7 +217,7 @@ async function sendAudio(blob) {
   if (!response.ok || data.error) {
     throw new Error(data.error || 'Ошибка сервера');
   }
-  handleServerResult(data);
+  handleServerResult({ ...data, source: data.source || 'audio' });
 }
 
 async function sendReceipt(file) {
@@ -196,21 +233,23 @@ async function sendReceipt(file) {
   if (!response.ok || data.error) {
     throw new Error(data.error || 'Ошибка распознавания');
   }
-  handleServerResult(data);
+  handleServerResult({ ...data, source: data.source || 'ocr' });
 }
 
 function handleServerResult(result) {
   const rawText = result.normalizedText || result.text || '';
   const normalizedText = typeof rawText === 'string' ? rawText.trim() : '';
-  transcriptBox.textContent = normalizedText || '—';
+  setTranscript(normalizedText);
 
   const parsed = parseRecognizedText(normalizedText);
   addressInput.value = parsed.address;
-  amountInput.value = parsed.amount;
+  amountInput.value = parsed.amount !== null ? String(parsed.amount) : '';
   phoneInput.value = parsed.phone ? formatPhone(parsed.phone) : '';
 
   updateCallAction();
   updateRouteAction();
+
+  pendingSource = result.source || 'recognition';
 
   const serverWarnings = Array.isArray(result.warnings) ? result.warnings : [];
   const combinedWarnings = mergeWarnings(serverWarnings, buildParsingWarnings(parsed));
@@ -219,12 +258,12 @@ function handleServerResult(result) {
 
 function parseRecognizedText(text) {
   if (!text) {
-    return { address: '', amount: '', phone: '' };
+    return { address: '', amount: null, phone: '' };
   }
 
   const normalized = text.replace(/\s+/g, ' ').trim();
   if (!normalized) {
-    return { address: '', amount: '', phone: '' };
+    return { address: '', amount: null, phone: '' };
   }
 
   const address = extractAddressFromText(normalized);
@@ -252,11 +291,18 @@ function extractAddressFromText(text) {
 
 function extractAmountFromText(text) {
   const compactNumbers = text.replace(/(\d)\s+(?=\d)/g, '$1');
-  const match = compactNumbers.match(/(\d{2,6})\s?(?:р|руб|₽)/i);
+  const match = compactNumbers.match(/(\d{2,6})(?:[\s.,](\d{2}))?\s?(?:р|руб|₽)/i);
   if (!match) {
-    return '';
+    return null;
   }
-  return match[1].replace(/\s+/g, '');
+  const major = match[1].replace(/\s+/g, '');
+  const minor = match[2] ? match[2] : '';
+  const raw = minor ? `${major}.${minor}` : major;
+  const amount = Number.parseFloat(raw.replace(',', '.'));
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  return Math.round(amount * 100) / 100;
 }
 
 function extractPhoneFromText(text) {
@@ -311,7 +357,7 @@ function buildParsingWarnings(parsed) {
   if (!parsed.address) {
     warnings.push('Адрес не найден в тексте');
   }
-  if (!parsed.amount) {
+  if (parsed.amount === null) {
     warnings.push('Сумма не найдена в тексте');
   }
   if (!parsed.phone) {
@@ -337,13 +383,14 @@ function mergeWarnings(serverWarnings, parsingWarnings) {
 
 function renderWarnings(items) {
   warningsBox.innerHTML = '';
+  latestWarnings = Array.isArray(items) ? [...items] : [];
   if (!items || items.length === 0) {
     return;
   }
   items.forEach((warning) => {
     const element = document.createElement('div');
     element.className = 'warning-item';
-    if (/не найден/i.test(warning)) {
+    if (/не найден/i.test(warning) || /укажите/i.test(warning)) {
       element.classList.add('critical');
     }
     element.textContent = warning;
@@ -375,14 +422,919 @@ function formatPhone(phone) {
   return phone;
 }
 
-function updateCallAction() {
-  const digits = phoneInput.value.replace(/\D/g, '');
-  if (digits.length >= 10) {
-    let normalized = digits.length === 10 ? `7${digits}` : digits;
-    if (normalized.length === 11 && normalized.startsWith('8')) {
-      normalized = `7${normalized.slice(1)}`;
+function setTranscript(text) {
+  const normalized = typeof text === 'string' ? text.trim() : '';
+  pendingRawText = normalized;
+  transcriptBox.textContent = normalized || '—';
+}
+
+function resetForm({ keepTranscript = false } = {}) {
+  addressInput.value = '';
+  amountInput.value = '';
+  phoneInput.value = '';
+  notesInput.value = '';
+  if (!keepTranscript) {
+    setTranscript('');
+  }
+  pendingSource = 'manual';
+  renderWarnings([]);
+  updateCallAction();
+  updateRouteAction();
+  setFormMode(null);
+}
+
+function setFormMode(order) {
+  if (order) {
+    editingOrderId = order.id;
+    formModeBadge.hidden = false;
+    const short = order.id.slice(-4).toUpperCase();
+    formModeBadge.textContent = `Редактирование заказа #${short}`;
+    saveOrderButton.textContent = 'Сохранить изменения';
+  } else {
+    editingOrderId = null;
+    formModeBadge.hidden = true;
+    saveOrderButton.textContent = 'Сохранить заказ';
+  }
+}
+
+function collectFormData() {
+  const address = addressInput.value.trim();
+  const amount = parseAmount(amountInput.value);
+  const normalizedPhone = normalizePhone(phoneInput.value);
+  const notes = notesInput.value.trim();
+  const rawText = pendingRawText;
+
+  return {
+    address,
+    amount,
+    phone: normalizedPhone,
+    notes,
+    rawText,
+  };
+}
+
+function parseAmount(raw) {
+  if (!raw) {
+    return null;
+  }
+  const cleaned = String(raw).replace(/\s+/g, '').replace(',', '.');
+  const amount = Number.parseFloat(cleaned);
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  return Math.round(amount * 100) / 100;
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  const formatter = new Intl.NumberFormat('ru-RU', {
+    minimumFractionDigits: value % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 2,
+  });
+  return `${formatter.format(value)} ₽`;
+}
+
+function pluralize(count, one, few, many) {
+  const mod10 = count % 10;
+  const mod100 = count % 100;
+  if (mod10 === 1 && mod100 !== 11) {
+    return `${count} ${one}`;
+  }
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
+    return `${count} ${few}`;
+  }
+  return `${count} ${many}`;
+}
+
+function translatePaymentMethod(method) {
+  return PAYMENT_LABELS[method] || '—';
+}
+
+function formatTime(timestamp) {
+  if (!timestamp) {
+    return '';
+  }
+  try {
+    return new Date(timestamp).toLocaleTimeString('ru-RU', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch (error) {
+    return '';
+  }
+}
+
+function generateId() {
+  return `ord-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getDefaultState() {
+  return {
+    activeOrders: [],
+    completedOrders: [],
+    cancelledOrders: [],
+  };
+}
+
+function sanitizeOrder(order) {
+  if (!order || typeof order !== 'object') {
+    return null;
+  }
+  const sanitized = {
+    id: typeof order.id === 'string' ? order.id : generateId(),
+    address: typeof order.address === 'string' ? order.address : '',
+    amount: typeof order.amount === 'number' && Number.isFinite(order.amount)
+      ? Math.round(order.amount * 100) / 100
+      : null,
+    phone: typeof order.phone === 'string' ? order.phone : '',
+    notes: typeof order.notes === 'string' ? order.notes : '',
+    rawText: typeof order.rawText === 'string' ? order.rawText : '',
+    createdAt: Number.isFinite(order.createdAt) ? order.createdAt : Date.now(),
+    status: ['pending', 'arrived', 'postponed'].includes(order.status) ? order.status : 'pending',
+    source: typeof order.source === 'string' ? order.source : 'manual',
+    warnings: Array.isArray(order.warnings) ? order.warnings.filter(Boolean) : [],
+    postponedCount: Number.isFinite(order.postponedCount) ? order.postponedCount : 0,
+    arrivedAt: Number.isFinite(order.arrivedAt) ? order.arrivedAt : null,
+    confirmedAmount: typeof order.confirmedAmount === 'number' && Number.isFinite(order.confirmedAmount)
+      ? Math.round(order.confirmedAmount * 100) / 100
+      : null,
+    completedAt: Number.isFinite(order.completedAt) ? order.completedAt : null,
+    cancelledAt: Number.isFinite(order.cancelledAt) ? order.cancelledAt : null,
+    payment: order.payment && typeof order.payment === 'object'
+      ? {
+          method: order.payment.method || null,
+          amount: typeof order.payment.amount === 'number' && Number.isFinite(order.payment.amount)
+            ? Math.round(order.payment.amount * 100) / 100
+            : null,
+        }
+      : null,
+  };
+  if (sanitized.phone) {
+    sanitized.phone = normalizePhone(sanitized.phone);
+  }
+  return sanitized;
+}
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return getDefaultState();
     }
-    callButton.href = `tel:+${normalized}`;
+    const parsed = JSON.parse(raw);
+    const active = Array.isArray(parsed.activeOrders)
+      ? parsed.activeOrders.map(sanitizeOrder).filter(Boolean)
+      : [];
+    const completed = Array.isArray(parsed.completedOrders)
+      ? parsed.completedOrders.map((order) => {
+          const sanitized = sanitizeOrder(order);
+          if (!sanitized) {
+            return null;
+          }
+          sanitized.status = 'completed';
+          return sanitized;
+        }).filter(Boolean)
+      : [];
+    const cancelled = Array.isArray(parsed.cancelledOrders)
+      ? parsed.cancelledOrders.map((order) => {
+          const sanitized = sanitizeOrder(order);
+          if (!sanitized) {
+            return null;
+          }
+          sanitized.status = 'cancelled';
+          return sanitized;
+        }).filter(Boolean)
+      : [];
+    return {
+      activeOrders: active,
+      completedOrders: completed,
+      cancelledOrders: cancelled,
+    };
+  } catch (error) {
+    console.warn('Failed to load state', error);
+    return getDefaultState();
+  }
+}
+
+function persistState() {
+  try {
+    const payload = JSON.stringify(state);
+    localStorage.setItem(STORAGE_KEY, payload);
+  } catch (error) {
+    console.warn('Не удалось сохранить состояние', error);
+  }
+}
+
+function buildOrderWarnings(data, existingWarnings = []) {
+  const filtered = existingWarnings.filter((warning) => {
+    if (data.address && /адрес/i.test(warning)) {
+      return false;
+    }
+    if (data.amount !== null && /сумм/i.test(warning)) {
+      return false;
+    }
+    if (data.phone && /телефон/i.test(warning)) {
+      return false;
+    }
+    return true;
+  });
+
+  if (data.amount === null && !filtered.some((warning) => /сумм/i.test(warning))) {
+    filtered.push('Сумма не указана');
+  }
+  if (!data.phone && !filtered.some((warning) => /телефон/i.test(warning))) {
+    filtered.push('Телефон не указан');
+  }
+  return mergeWarnings(filtered, []);
+}
+
+function saveCurrentOrder() {
+  const data = collectFormData();
+  if (!data.address) {
+    addressInput.focus();
+    renderWarnings(['Укажите адрес доставки']);
+    return;
+  }
+
+  const orderWarnings = buildOrderWarnings(data, latestWarnings);
+
+  if (editingOrderId) {
+    const order = state.activeOrders.find((item) => item.id === editingOrderId);
+    if (!order) {
+      setFormMode(null);
+    } else {
+      order.address = data.address;
+      order.amount = data.amount;
+      order.phone = data.phone;
+      order.notes = data.notes;
+      order.rawText = data.rawText;
+      order.source = pendingSource || order.source;
+      order.warnings = orderWarnings;
+    }
+  } else {
+    const newOrder = {
+      id: generateId(),
+      address: data.address,
+      amount: data.amount,
+      phone: data.phone,
+      notes: data.notes,
+      rawText: data.rawText,
+      createdAt: Date.now(),
+      status: 'pending',
+      source: pendingSource || 'manual',
+      warnings: orderWarnings,
+      postponedCount: 0,
+      arrivedAt: null,
+      confirmedAmount: null,
+      completedAt: null,
+      payment: null,
+    };
+    state.activeOrders.push(newOrder);
+  }
+
+  persistState();
+  renderActiveOrders();
+  renderCompletedOrders();
+  updateStatus('Заказ сохранён', 'success');
+  resetForm();
+}
+
+function loadOrderIntoForm(order) {
+  addressInput.value = order.address || '';
+  amountInput.value = order.amount !== null ? String(order.amount) : '';
+  phoneInput.value = order.phone ? formatPhone(order.phone) : '';
+  notesInput.value = order.notes || '';
+  pendingSource = order.source || 'manual';
+  setTranscript(order.rawText || '');
+  renderWarnings(order.warnings || []);
+  updateCallAction();
+  updateRouteAction();
+  setFormMode(order);
+}
+
+function renderActiveOrders() {
+  activeOrdersList.innerHTML = '';
+  if (!state.activeOrders.length) {
+    activeOrdersEmpty.style.display = 'block';
+  } else {
+    activeOrdersEmpty.style.display = 'none';
+  }
+
+  state.activeOrders.forEach((order, index) => {
+    const card = document.createElement('div');
+    card.className = 'order-card';
+    card.dataset.id = order.id;
+
+    const header = document.createElement('div');
+    header.className = 'order-header';
+
+    const main = document.createElement('div');
+    main.className = 'order-main';
+
+    const title = document.createElement('div');
+    title.className = 'order-title';
+    title.textContent = `№${index + 1} • ${order.address || 'Без адреса'}`;
+
+    const meta = document.createElement('div');
+    meta.className = 'order-meta';
+
+    const amount = document.createElement('span');
+    amount.className = 'order-amount';
+    amount.textContent = order.amount !== null ? formatCurrency(order.amount) : 'Сумма не указана';
+    meta.appendChild(amount);
+
+    if (order.phone) {
+      const phone = document.createElement('span');
+      phone.className = 'order-phone';
+      phone.textContent = formatPhone(order.phone);
+      meta.appendChild(phone);
+    }
+
+    if (order.postponedCount > 0) {
+      const postponed = document.createElement('span');
+      postponed.textContent = pluralize(order.postponedCount, 'Отложен 1 раз', 'Отложен 2 раза', `Отложен ${order.postponedCount} раз`);
+      meta.appendChild(postponed);
+    }
+
+    if (order.arrivedAt) {
+      const arrived = document.createElement('span');
+      arrived.textContent = `На месте: ${formatTime(order.arrivedAt)}`;
+      meta.appendChild(arrived);
+    }
+
+    main.appendChild(title);
+    main.appendChild(meta);
+
+    const reorder = document.createElement('div');
+    reorder.className = 'order-reorder';
+
+    const upButton = document.createElement('button');
+    upButton.className = 'icon-button';
+    upButton.type = 'button';
+    upButton.dataset.action = 'move-up';
+    upButton.textContent = '↑';
+    upButton.setAttribute('aria-label', 'Переместить заказ выше');
+    if (index === 0) {
+      upButton.disabled = true;
+    }
+
+    const downButton = document.createElement('button');
+    downButton.className = 'icon-button';
+    downButton.type = 'button';
+    downButton.dataset.action = 'move-down';
+    downButton.textContent = '↓';
+    downButton.setAttribute('aria-label', 'Переместить заказ ниже');
+    if (index === state.activeOrders.length - 1) {
+      downButton.disabled = true;
+    }
+
+    reorder.appendChild(upButton);
+    reorder.appendChild(downButton);
+
+    header.appendChild(main);
+    header.appendChild(reorder);
+    card.appendChild(header);
+
+    const badges = document.createElement('div');
+    badges.className = 'order-badges';
+
+    if (order.status === 'arrived') {
+      const badge = document.createElement('span');
+      badge.className = 'badge success';
+      badge.textContent = 'На месте';
+      badges.appendChild(badge);
+    }
+    if (order.status === 'postponed') {
+      const badge = document.createElement('span');
+      badge.className = 'badge warning';
+      badge.textContent = 'Отложен';
+      badges.appendChild(badge);
+    }
+    if (order.source === 'audio') {
+      const badge = document.createElement('span');
+      badge.className = 'badge info';
+      badge.textContent = 'Голос';
+      badges.appendChild(badge);
+    }
+    if (order.source === 'ocr') {
+      const badge = document.createElement('span');
+      badge.className = 'badge info';
+      badge.textContent = 'Чек';
+      badges.appendChild(badge);
+    }
+    if (order.warnings && order.warnings.length) {
+      const badge = document.createElement('span');
+      badge.className = 'badge warning';
+      badge.textContent = 'Проверьте данные';
+      badges.appendChild(badge);
+    }
+
+    if (badges.childElementCount > 0) {
+      card.appendChild(badges);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'order-actions';
+
+    const callAction = document.createElement('a');
+    callAction.className = 'order-action';
+    callAction.dataset.action = 'call';
+    callAction.textContent = 'Позвонить';
+    callAction.rel = 'noopener';
+    if (order.phone) {
+      callAction.href = `tel:${order.phone.replace(/\D/g, '').replace(/^7/, '+7')}`;
+    } else {
+      callAction.href = '#';
+      callAction.classList.add('disabled');
+      callAction.setAttribute('aria-disabled', 'true');
+    }
+
+    const routeAction = document.createElement('a');
+    routeAction.className = 'order-action secondary';
+    routeAction.dataset.action = 'navigate';
+    routeAction.textContent = 'Маршрут';
+    routeAction.rel = 'noopener';
+    routeAction.target = '_blank';
+    if (order.address) {
+      const encoded = encodeURIComponent(order.address);
+      routeAction.href = `yandexnavi://search?text=${encoded}`;
+      routeAction.dataset.fallback = `https://yandex.ru/maps/?text=${encoded}`;
+    } else {
+      routeAction.href = '#';
+      routeAction.classList.add('disabled');
+      routeAction.setAttribute('aria-disabled', 'true');
+    }
+
+    const arriveAction = document.createElement('button');
+    arriveAction.className = 'order-action';
+    arriveAction.type = 'button';
+    arriveAction.dataset.action = 'arrive';
+    arriveAction.textContent = order.status === 'arrived' ? 'В пути' : 'На месте';
+
+    const postponeAction = document.createElement('button');
+    postponeAction.className = 'order-action';
+    postponeAction.type = 'button';
+    postponeAction.dataset.action = 'postpone';
+    postponeAction.textContent = 'Отложить';
+
+    const editAction = document.createElement('button');
+    editAction.className = 'order-action ghost';
+    editAction.type = 'button';
+    editAction.dataset.action = 'edit';
+    editAction.textContent = 'Редактировать';
+
+    const cancelAction = document.createElement('button');
+    cancelAction.className = 'order-action danger';
+    cancelAction.type = 'button';
+    cancelAction.dataset.action = 'cancel';
+    cancelAction.textContent = 'Отменить';
+
+    const completeAction = document.createElement('button');
+    completeAction.className = 'order-action primary';
+    completeAction.type = 'button';
+    completeAction.dataset.action = 'complete';
+    completeAction.textContent = 'Завершить';
+
+    actions.appendChild(callAction);
+    actions.appendChild(routeAction);
+    actions.appendChild(arriveAction);
+    actions.appendChild(postponeAction);
+    actions.appendChild(completeAction);
+    actions.appendChild(editAction);
+    actions.appendChild(cancelAction);
+
+    card.appendChild(actions);
+
+    const detailText = order.notes || order.rawText;
+    if (detailText) {
+      const notes = document.createElement('div');
+      notes.className = 'order-notes';
+      notes.textContent = detailText;
+      card.appendChild(notes);
+    }
+
+    if (order.warnings && order.warnings.length) {
+      const warningBox = document.createElement('div');
+      warningBox.className = 'order-warning';
+
+      const warningTitle = document.createElement('div');
+      warningTitle.className = 'order-warning-title';
+      warningTitle.textContent = 'Предупреждения';
+      warningBox.appendChild(warningTitle);
+
+      const warningList = document.createElement('ul');
+      warningList.className = 'order-warning-list';
+      order.warnings.forEach((warning) => {
+        const item = document.createElement('li');
+        item.textContent = warning;
+        warningList.appendChild(item);
+      });
+      warningBox.appendChild(warningList);
+
+      card.appendChild(warningBox);
+    }
+
+    activeOrdersList.appendChild(card);
+  });
+
+  updateStartRouteAction();
+}
+
+function updateStartRouteAction() {
+  const addresses = state.activeOrders.map((order) => order.address).filter((address) => !!address);
+  if (!addresses.length) {
+    startRouteButton.href = '#';
+    startRouteButton.dataset.fallback = '';
+    startRouteButton.classList.add('disabled');
+    startRouteButton.setAttribute('aria-disabled', 'true');
+    return;
+  }
+
+  const primary = buildNavigatorLink(addresses);
+  const fallback = buildMapsFallback(addresses);
+  startRouteButton.href = primary;
+  startRouteButton.dataset.fallback = fallback;
+  startRouteButton.classList.remove('disabled');
+  startRouteButton.setAttribute('aria-disabled', 'false');
+}
+
+function buildNavigatorLink(addresses) {
+  const points = addresses.map((address) => `ymapsbm1://geo?text=${encodeURIComponent(address)}`);
+  return `yandexnavi://build_route_on_map?points=${points.join('~')}`;
+}
+
+function buildMapsFallback(addresses) {
+  const encoded = addresses.map((address) => encodeURIComponent(address));
+  return `https://yandex.ru/maps/?rtext=~${encoded.join('~')}&rtt=auto`;
+}
+
+function renderCompletedOrders() {
+  completedOrdersList.innerHTML = '';
+  if (!state.completedOrders.length) {
+    completedSummary.classList.add('empty');
+    completedSummary.textContent = 'Заказов пока нет.';
+  } else {
+    completedSummary.classList.remove('empty');
+    const totals = state.completedOrders.reduce((acc, order) => {
+      acc.total += 1;
+      const method = order.payment ? order.payment.method : null;
+      const amount = order.payment && typeof order.payment.amount === 'number' ? order.payment.amount : order.confirmedAmount;
+      if (method === 'cash') {
+        acc.cash += amount || 0;
+        acc.cashCount += 1;
+      } else if (method === 'transfer') {
+        acc.transfer += amount || 0;
+        acc.transferCount += 1;
+      } else if (method === 'card') {
+        acc.card += amount || 0;
+        acc.cardCount += 1;
+      }
+      return acc;
+    }, {
+      total: 0,
+      cash: 0,
+      cashCount: 0,
+      transfer: 0,
+      transferCount: 0,
+      card: 0,
+      cardCount: 0,
+    });
+
+    const lines = [];
+    lines.push(`Завершённых заказов: ${pluralize(totals.total, 'заказ', 'заказа', 'заказов')}`);
+    lines.push(`Наличные: ${formatCurrency(totals.cash)}`);
+    lines.push(`Переводы: ${formatCurrency(totals.transfer)}`);
+    const cardLine = totals.cardCount
+      ? `${pluralize(totals.cardCount, 'заказ', 'заказа', 'заказов')} (${formatCurrency(totals.card)})`
+      : '0 заказов';
+    lines.push(`Оплата картой: ${cardLine}`);
+
+    completedSummary.innerHTML = lines.map((line) => `<div>${line}</div>`).join('');
+  }
+
+  state.completedOrders.forEach((order) => {
+    const item = document.createElement('div');
+    item.className = 'history-item';
+
+    const title = document.createElement('div');
+    title.className = 'history-title';
+    title.textContent = order.address || 'Без адреса';
+
+    const meta = document.createElement('div');
+    meta.className = 'history-meta';
+
+    if (order.payment) {
+      const amount = document.createElement('span');
+      amount.textContent = `Сумма: ${formatCurrency(order.payment.amount)}`;
+      meta.appendChild(amount);
+
+      const method = document.createElement('span');
+      method.textContent = `Оплата: ${translatePaymentMethod(order.payment.method)}`;
+      meta.appendChild(method);
+    }
+
+    if (order.amount !== null && order.payment && order.payment.amount !== order.amount) {
+      const expected = document.createElement('span');
+      expected.textContent = `По чеку: ${formatCurrency(order.amount)}`;
+      meta.appendChild(expected);
+    }
+
+    if (order.phone) {
+      const phone = document.createElement('span');
+      phone.textContent = formatPhone(order.phone);
+      meta.appendChild(phone);
+    }
+
+    if (order.completedAt) {
+      const completedAt = document.createElement('span');
+      completedAt.textContent = `Завершено: ${formatTime(order.completedAt)}`;
+      meta.appendChild(completedAt);
+    }
+
+    item.appendChild(title);
+    if (meta.childElementCount > 0) {
+      item.appendChild(meta);
+    }
+
+    const detailText = order.notes || order.rawText;
+    if (detailText) {
+      const notes = document.createElement('div');
+      notes.className = 'history-notes';
+      notes.textContent = detailText;
+      item.appendChild(notes);
+    }
+
+    completedOrdersList.appendChild(item);
+  });
+
+  renderCancelledOrders();
+}
+
+function renderCancelledOrders() {
+  cancelledOrdersList.innerHTML = '';
+  if (!state.cancelledOrders.length) {
+    cancelledWrapper.hidden = true;
+    return;
+  }
+  cancelledWrapper.hidden = false;
+
+  state.cancelledOrders.forEach((order) => {
+    const item = document.createElement('div');
+    item.className = 'history-item';
+
+    const title = document.createElement('div');
+    title.className = 'history-title';
+    title.textContent = order.address || 'Без адреса';
+
+    const meta = document.createElement('div');
+    meta.className = 'history-meta';
+
+    if (order.amount !== null) {
+      const amount = document.createElement('span');
+      amount.textContent = `Сумма: ${formatCurrency(order.amount)}`;
+      meta.appendChild(amount);
+    }
+
+    if (order.cancelledAt) {
+      const cancelledAt = document.createElement('span');
+      cancelledAt.textContent = `Отменён: ${formatTime(order.cancelledAt)}`;
+      meta.appendChild(cancelledAt);
+    }
+
+    item.appendChild(title);
+    if (meta.childElementCount > 0) {
+      item.appendChild(meta);
+    }
+
+    const detailText = order.notes || order.rawText;
+    if (detailText) {
+      const notes = document.createElement('div');
+      notes.className = 'history-notes';
+      notes.textContent = detailText;
+      item.appendChild(notes);
+    }
+
+    cancelledOrdersList.appendChild(item);
+  });
+}
+
+function handleActiveOrderClick(event) {
+  const target = event.target.closest('[data-action]');
+  if (!target) {
+    return;
+  }
+  const card = target.closest('.order-card');
+  if (!card) {
+    return;
+  }
+  const orderId = card.dataset.id;
+  const action = target.dataset.action;
+
+  if (!orderId || !action) {
+    return;
+  }
+
+  if (action === 'call') {
+    if (target.classList.contains('disabled')) {
+      event.preventDefault();
+    }
+    return;
+  }
+
+  if (action === 'navigate') {
+    if (target.classList.contains('disabled')) {
+      event.preventDefault();
+      return;
+    }
+    const fallback = target.dataset.fallback;
+    if (fallback) {
+      setTimeout(() => {
+        window.open(fallback, '_blank', 'noopener');
+      }, 800);
+    }
+    return;
+  }
+
+  event.preventDefault();
+
+  switch (action) {
+    case 'move-up':
+      moveOrder(orderId, -1);
+      break;
+    case 'move-down':
+      moveOrder(orderId, 1);
+      break;
+    case 'arrive':
+      toggleArrived(orderId);
+      break;
+    case 'postpone':
+      postponeOrder(orderId);
+      break;
+    case 'cancel':
+      cancelOrder(orderId);
+      break;
+    case 'edit':
+      editOrder(orderId);
+      break;
+    case 'complete':
+      openCompletionDialog(orderId);
+      break;
+    default:
+      break;
+  }
+}
+
+function moveOrder(orderId, direction) {
+  const index = state.activeOrders.findIndex((order) => order.id === orderId);
+  if (index === -1) {
+    return;
+  }
+  const newIndex = index + direction;
+  if (newIndex < 0 || newIndex >= state.activeOrders.length) {
+    return;
+  }
+  const [order] = state.activeOrders.splice(index, 1);
+  state.activeOrders.splice(newIndex, 0, order);
+  persistState();
+  renderActiveOrders();
+}
+
+function toggleArrived(orderId) {
+  const order = state.activeOrders.find((item) => item.id === orderId);
+  if (!order) {
+    return;
+  }
+  if (order.status === 'arrived') {
+    order.status = 'pending';
+    order.arrivedAt = null;
+  } else {
+    order.status = 'arrived';
+    order.arrivedAt = Date.now();
+  }
+  persistState();
+  renderActiveOrders();
+}
+
+function postponeOrder(orderId) {
+  const index = state.activeOrders.findIndex((order) => order.id === orderId);
+  if (index === -1) {
+    return;
+  }
+  const [order] = state.activeOrders.splice(index, 1);
+  order.status = 'postponed';
+  order.postponedCount = (order.postponedCount || 0) + 1;
+  order.arrivedAt = null;
+  state.activeOrders.push(order);
+  persistState();
+  renderActiveOrders();
+}
+
+function cancelOrder(orderId) {
+  const index = state.activeOrders.findIndex((order) => order.id === orderId);
+  if (index === -1) {
+    return;
+  }
+  const order = state.activeOrders[index];
+  const confirmed = window.confirm('Отменить этот заказ?');
+  if (!confirmed) {
+    return;
+  }
+  const [removed] = state.activeOrders.splice(index, 1);
+  removed.status = 'cancelled';
+  removed.cancelledAt = Date.now();
+  state.cancelledOrders.push(removed);
+  persistState();
+  renderActiveOrders();
+  renderCompletedOrders();
+}
+
+function editOrder(orderId) {
+  const order = state.activeOrders.find((item) => item.id === orderId);
+  if (!order) {
+    return;
+  }
+  loadOrderIntoForm(order);
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function openCompletionDialog(orderId) {
+  const order = state.activeOrders.find((item) => item.id === orderId);
+  if (!order) {
+    return;
+  }
+  completionOrderId = orderId;
+  completeAddress.textContent = order.address || 'Без адреса';
+  completeMethod.value = order.payment?.method || 'cash';
+  const amountValue = order.confirmedAmount ?? order.amount;
+  completeAmount.value = amountValue !== null && amountValue !== undefined ? String(amountValue) : '';
+  completeOverlay.hidden = false;
+  completeConfirm.focus();
+}
+
+function closeCompletionDialog() {
+  completionOrderId = null;
+  completeOverlay.hidden = true;
+  completeAmount.value = '';
+}
+
+function finalizeOrder() {
+  if (!completionOrderId) {
+    return;
+  }
+  const orderIndex = state.activeOrders.findIndex((item) => item.id === completionOrderId);
+  if (orderIndex === -1) {
+    closeCompletionDialog();
+    return;
+  }
+  const order = state.activeOrders[orderIndex];
+  const method = completeMethod.value || 'cash';
+  let amount = parseAmount(completeAmount.value);
+  if (amount === null) {
+    amount = order.amount;
+  }
+  if (amount === null) {
+    completeAmount.setCustomValidity('Укажите сумму оплаты');
+    completeAmount.reportValidity();
+    completeAmount.setCustomValidity('');
+    return;
+  }
+
+  order.confirmedAmount = amount;
+  order.completedAt = Date.now();
+  order.payment = {
+    method,
+    amount,
+  };
+  order.status = 'completed';
+
+  state.activeOrders.splice(orderIndex, 1);
+  state.completedOrders.push(order);
+  persistState();
+  closeCompletionDialog();
+  renderActiveOrders();
+  renderCompletedOrders();
+}
+
+function finishDay() {
+  const confirmed = window.confirm('Очистить все данные за день?');
+  if (!confirmed) {
+    return;
+  }
+  state = getDefaultState();
+  persistState();
+  renderActiveOrders();
+  renderCompletedOrders();
+  resetForm();
+  updateStatus('Данные дня очищены', 'muted');
+}
+
+function updateCallAction() {
+  const normalized = normalizePhone(phoneInput.value);
+  if (normalized) {
+    const digits = normalized.replace('+', '');
+    callButton.href = `tel:+${digits}`;
     callButton.classList.remove('disabled');
     callButton.setAttribute('aria-disabled', 'false');
   } else {
@@ -421,6 +1373,21 @@ routeButton.addEventListener('click', (event) => {
   }
 });
 
+[startRouteButton].forEach((anchor) => {
+  anchor.addEventListener('click', (event) => {
+    if (anchor.classList.contains('disabled')) {
+      event.preventDefault();
+      return;
+    }
+    const fallback = anchor.dataset.fallback;
+    if (fallback) {
+      setTimeout(() => {
+        window.open(fallback, '_blank', 'noopener');
+      }, 800);
+    }
+  });
+});
+
 [addressInput, phoneInput].forEach((input) => {
   input.addEventListener('input', () => {
     if (input === phoneInput) {
@@ -430,6 +1397,12 @@ routeButton.addEventListener('click', (event) => {
       updateRouteAction();
     }
   });
+});
+
+phoneInput.addEventListener('blur', () => {
+  const normalized = normalizePhone(phoneInput.value);
+  phoneInput.value = normalized ? formatPhone(normalized) : phoneInput.value.trim();
+  updateCallAction();
 });
 
 receiptInput.addEventListener('change', async () => {
@@ -451,6 +1424,46 @@ receiptInput.addEventListener('change', async () => {
   receiptInput.value = '';
 });
 
-updateCallAction();
-updateRouteAction();
-updateStatus('Готов к записи', 'idle');
+saveOrderButton.addEventListener('click', () => {
+  saveCurrentOrder();
+});
+
+resetFormButton.addEventListener('click', () => {
+  resetForm({ keepTranscript: false });
+  updateStatus('Форма очищена', 'muted');
+});
+
+activeOrdersList.addEventListener('click', handleActiveOrderClick);
+
+completeCancel.addEventListener('click', () => {
+  closeCompletionDialog();
+});
+
+completeClose.addEventListener('click', () => {
+  closeCompletionDialog();
+});
+
+completeConfirm.addEventListener('click', () => {
+  finalizeOrder();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !completeOverlay.hidden) {
+    closeCompletionDialog();
+  }
+});
+
+finishDayButton.addEventListener('click', () => {
+  finishDay();
+});
+
+function initialize() {
+  renderActiveOrders();
+  renderCompletedOrders();
+  updateCallAction();
+  updateRouteAction();
+  setTranscript('');
+  updateStatus('Готов к записи', 'idle');
+}
+
+initialize();

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -30,8 +30,9 @@
           <div id="transcript" class="transcript" aria-live="polite">—</div>
         </section>
 
-        <section class="form-card">
+        <section class="form-card" id="order-form-card">
           <div class="section-title">Данные доставки</div>
+          <div id="form-mode" class="form-mode" hidden>Новый заказ</div>
           <label class="input-group">
             <span>Адрес</span>
             <input
@@ -62,6 +63,19 @@
               placeholder="+7 999 123-45-67"
             />
           </label>
+          <label class="input-group">
+            <span>Комментарий</span>
+            <textarea
+              id="notes"
+              name="notes"
+              rows="2"
+              placeholder="Примечания или дополнительные контакты"
+            ></textarea>
+          </label>
+          <div class="form-actions">
+            <button id="save-order-button" class="primary-button" type="button">Сохранить заказ</button>
+            <button id="reset-form-button" class="secondary-button" type="button">Очистить</button>
+          </div>
         </section>
 
         <section class="actions-card">
@@ -79,12 +93,62 @@
           <div id="upload-hint" class="upload-hint">Фото будет обработано сразу после выбора.</div>
         </section>
 
+        <section class="orders-card">
+          <div class="section-header">
+            <div class="section-title">Активные заказы</div>
+            <a id="start-route-button" class="section-action disabled" href="#" rel="noopener" aria-disabled="true">Поехали</a>
+          </div>
+          <div id="active-orders-empty" class="empty-state">Добавьте заказы через форму выше, чтобы построить маршрут.</div>
+          <div id="active-orders-list" class="orders-list" aria-live="polite"></div>
+        </section>
+
+        <section class="history-card">
+          <div class="section-header">
+            <div class="section-title">Завершённые заказы</div>
+            <button id="finish-day-button" class="section-action outline" type="button">Завершить день</button>
+          </div>
+          <div id="completed-summary" class="summary-box empty">Заказов пока нет.</div>
+          <div id="completed-orders-list" class="history-list"></div>
+          <div id="cancelled-orders-wrapper" class="history-subsection" hidden>
+            <div class="subsection-title">Отменённые заказы</div>
+            <div id="cancelled-orders-list" class="history-list"></div>
+          </div>
+        </section>
+
         <section id="warnings" class="warnings" aria-live="assertive"></section>
       </main>
 
       <footer class="app-footer">
         <span>Фиксируйте заказы без клавиатуры</span>
       </footer>
+    </div>
+
+    <div id="complete-overlay" class="modal" role="dialog" aria-modal="true" hidden>
+      <div class="modal-content">
+        <div class="modal-header">
+          <div class="modal-title">Завершение заказа</div>
+          <button id="complete-close" class="icon-button" type="button" aria-label="Закрыть">✕</button>
+        </div>
+        <div class="modal-body">
+          <div id="complete-address" class="modal-address"></div>
+          <label class="input-group">
+            <span>Способ оплаты</span>
+            <select id="complete-method" name="complete-method">
+              <option value="cash">Наличные</option>
+              <option value="transfer">Перевод</option>
+              <option value="card">Карта</option>
+            </select>
+          </label>
+          <label class="input-group">
+            <span>Полученная сумма, ₽</span>
+            <input id="complete-amount" name="complete-amount" type="number" inputmode="decimal" placeholder="Сколько оплатил клиент" />
+          </label>
+        </div>
+        <div class="modal-actions">
+          <button id="complete-cancel" class="secondary-button" type="button">Отмена</button>
+          <button id="complete-confirm" class="primary-button" type="button">Сохранить</button>
+        </div>
+      </div>
     </div>
 
     <script src="/app.js" type="module"></script>

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -28,7 +28,7 @@ body {
 }
 
 .app-shell {
-  width: min(480px, 100%);
+  width: min(500px, 100%);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -95,12 +95,54 @@ body {
 .transcript-card,
 .form-card,
 .actions-card,
-.upload-card {
+.upload-card,
+.orders-card,
+.history-card {
   background: var(--card);
   border-radius: 18px;
   padding: 20px;
   box-shadow: var(--shadow);
   border: 1px solid var(--border);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.section-header .section-title {
+  margin-bottom: 0;
+}
+
+.section-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.18);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: opacity 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.section-action.outline {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.45);
+  color: var(--muted);
+}
+
+.section-action.disabled {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 .record-button {
@@ -164,7 +206,9 @@ body {
   color: var(--muted);
 }
 
-.input-group input {
+.input-group input,
+.input-group textarea,
+.input-group select {
   width: 100%;
   padding: 14px 16px;
   border-radius: 12px;
@@ -174,9 +218,70 @@ body {
   font-size: 1rem;
 }
 
-.input-group input:focus {
+.input-group textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+
+.input-group input:focus,
+.input-group textarea:focus,
+.input-group select:focus {
   outline: 2px solid rgba(59, 130, 246, 0.35);
   border-color: rgba(59, 130, 246, 0.5);
+}
+
+.form-mode {
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(59, 130, 246, 0.16);
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.primary-button,
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 14px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, opacity 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: white;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.35);
+}
+
+.primary-button:active {
+  transform: scale(0.98);
+}
+
+.secondary-button {
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.primary-button[disabled],
+.secondary-button[disabled] {
+  opacity: 0.45;
+  pointer-events: none;
 }
 
 .actions-card {
@@ -232,6 +337,321 @@ body {
   color: var(--muted);
 }
 
+.empty-state {
+  font-size: 0.9rem;
+  color: var(--muted);
+  padding: 12px 0;
+}
+
+.orders-list,
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.order-card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(15, 17, 23, 0.65);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.order-reorder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.order-main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.order-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.order-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.order-amount {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.order-phone {
+  color: var(--muted);
+}
+
+.order-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--muted);
+}
+
+.badge.success {
+  background: rgba(34, 197, 94, 0.22);
+  color: #4ade80;
+}
+
+.badge.warning {
+  background: rgba(249, 115, 22, 0.22);
+  color: #fb923c;
+}
+
+.badge.info {
+  background: rgba(59, 130, 246, 0.18);
+  color: #93c5fd;
+}
+
+.order-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.order-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.order-action.primary {
+  background: linear-gradient(120deg, rgba(59, 130, 246, 0.85), rgba(37, 99, 235, 0.95));
+  border-color: transparent;
+}
+
+.order-action.secondary {
+  background: rgba(147, 51, 234, 0.18);
+  border-color: rgba(147, 51, 234, 0.32);
+}
+
+.order-action.danger {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #fca5a5;
+}
+
+.order-action.ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--muted);
+}
+
+.order-action.disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.order-notes {
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: rgba(15, 23, 42, 0.35);
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  white-space: pre-wrap;
+}
+
+.order-warning {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(249, 115, 22, 0.35);
+  background: rgba(249, 115, 22, 0.18);
+  color: #fbbf24;
+  font-size: 0.85rem;
+}
+
+.order-warning-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: #fdba74;
+}
+
+.order-warning-list {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.order-warning-list li {
+  list-style: disc;
+}
+
+.icon-button {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.icon-button[disabled] {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.summary-box {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(59, 130, 246, 0.28);
+  background: rgba(59, 130, 246, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+.summary-box.empty {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+}
+
+.history-item {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: rgba(15, 17, 23, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-item .history-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.history-item .history-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.history-item .history-notes {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  white-space: pre-wrap;
+}
+
+.history-subsection {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.subsection-title {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 17, 23, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 100;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-content {
+  width: min(420px, 100%);
+  background: var(--card);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.modal-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modal-address {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
 .warnings {
   display: flex;
   flex-direction: column;
@@ -267,6 +687,19 @@ body {
   }
 
   .record-button {
+    padding: 16px;
+  }
+
+  .order-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .order-actions {
+    justify-content: flex-start;
+  }
+
+  .modal {
     padding: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the main form to capture address, amount, phone and notes for orders with save/reset actions
- add local state management for active, completed and cancelled orders including reordering, warnings, and Yandex Navigator route launch
- implement completion dialog with payment tracking, per-day statistics, and dedicated styling for order lists, warnings, and modal UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd3c5f0fc83239a4e0776aa9a96e5