### PR TITLE
Add fallback OCR provider when Google Vision unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ npm run dev
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=whisper-1          # необязательно
 GOOGLE_VISION_API_KEY=...        # ключ Google Cloud Vision API
+OCR_SPACE_API_KEY=helloworld     # резервный ключ OCR.space (опционально)
 MOCK_TRANSCRIBE_TEXT=...         # необязательный текст для офлайн-демо
 MOCK_OCR_TEXT=...                # необязательный текст для офлайн-демо
 PORT=3000                        # необязательно
 ```
 
 Если ключи OpenAI/Google Vision отсутствуют, сервер вернёт содержимое переменных `MOCK_TRANSCRIBE_TEXT` / `MOCK_OCR_TEXT` (или пустую строку). Это удобно для локальной отладки без внешних API.
+
+При отсутствии `GOOGLE_VISION_API_KEY` приложение автоматически переключится на бесплатный OCR сервис [OCR.space](https://ocr.space/). При желании можно задать собственный ключ через `OCR_SPACE_API_KEY` (по умолчанию используется демо-ключ `helloworld`).
 
 ### Скрипты npm
 

--- a/src/server/services/ocr.js
+++ b/src/server/services/ocr.js
@@ -1,9 +1,16 @@
 const { ensureMimeType } = require('../utils/base64');
 const { parseCourierText } = require('../utils/parser');
 
+const OCR_SPACE_ENDPOINT = 'https://api.ocr.space/parse/image';
+
 async function recognizeReceipt(buffer, providedMime) {
-  const mimeType = ensureMimeType(providedMime, 'image/jpeg');
-  if (!mimeType.startsWith('image/')) {
+  let mimeType = ensureMimeType(providedMime, 'image/jpeg');
+  if (!mimeType || typeof mimeType !== 'string') {
+    mimeType = 'image/jpeg';
+  }
+
+  const normalizedMime = mimeType.toLowerCase();
+  if (!normalizedMime.startsWith('image/')) {
     throw new Error('Поддерживаются только изображения');
   }
 
@@ -11,22 +18,60 @@ async function recognizeReceipt(buffer, providedMime) {
     throw new Error('Пустое изображение');
   }
 
-  const text = await runVision(buffer, mimeType);
-  const parsed = parseCourierText(text);
+  const { text: recognizedText, warnings: recognitionWarnings } = await recognizeTextWithFallback(buffer, normalizedMime);
+  const trimmedText = typeof recognizedText === 'string' ? recognizedText.trim() : '';
+  const parsed = parseCourierText(trimmedText);
+  const combinedWarnings = mergeWarnings(recognitionWarnings, parsed.warnings);
+
   return {
-    text,
+    text: trimmedText,
     normalizedText: parsed.normalizedText,
     address: parsed.address,
     amount: parsed.amount,
     phone: parsed.phone,
-    warnings: parsed.warnings,
+    warnings: combinedWarnings,
   };
 }
 
-async function runVision(buffer, mimeType) {
+async function recognizeTextWithFallback(buffer, mimeType) {
+  const warnings = [];
+
+  const primary = await tryGoogleVision(buffer, mimeType);
+  pushWarning(warnings, primary.warning);
+
+  let text = primary.text || '';
+
+  if (!text) {
+    const fallback = await tryOcrSpace(buffer, mimeType);
+    pushWarning(warnings, fallback.warning);
+    if (fallback.text) {
+      text = fallback.text;
+      pushWarning(warnings, 'Использован резервный сервис распознавания OCR.space');
+    }
+  }
+
+  if (!text) {
+    const mockText = typeof process.env.MOCK_OCR_TEXT === 'string' ? process.env.MOCK_OCR_TEXT.trim() : '';
+    if (mockText) {
+      text = mockText;
+      pushWarning(warnings, 'Использован текст из переменной MOCK_OCR_TEXT');
+    }
+  }
+
+  return {
+    text: typeof text === 'string' ? text.trim() : '',
+    warnings,
+  };
+}
+
+async function tryGoogleVision(buffer, mimeType) {
   const apiKey = process.env.GOOGLE_VISION_API_KEY;
   if (!apiKey) {
-    return process.env.MOCK_OCR_TEXT || '';
+    return {
+      ok: false,
+      text: '',
+      warning: 'Google Vision API недоступен, используется резервное распознавание',
+    };
   }
 
   const body = {
@@ -39,25 +84,147 @@ async function runVision(buffer, mimeType) {
     ],
   };
 
-  const response = await fetch(`https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
+  try {
+    const response = await fetch(`https://vision.googleapis.com/v1/images:annotate?key=${apiKey}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      console.error('Google Vision OCR error:', message);
+      return {
+        ok: false,
+        text: '',
+        warning: 'Не удалось получить ответ от Google Vision',
+      };
+    }
+
+    const payload = await response.json();
+    const annotation = payload.responses?.[0];
+    const text = annotation?.fullTextAnnotation?.text
+      || annotation?.textAnnotations?.[0]?.description
+      || '';
+
+    return {
+      ok: true,
+      text: typeof text === 'string' ? text.trim() : '',
+      warning: null,
+    };
+  } catch (error) {
+    console.error('Google Vision OCR request failed:', error);
+    return {
+      ok: false,
+      text: '',
+      warning: 'Ошибка запроса к Google Vision',
+    };
+  }
+}
+
+async function tryOcrSpace(buffer, mimeType) {
+  const apiKey = process.env.OCR_SPACE_API_KEY || 'helloworld';
+  const params = new URLSearchParams();
+  params.set('language', 'rus');
+  params.set('scale', 'true');
+  params.set('detectOrientation', 'true');
+  params.set('isOverlayRequired', 'false');
+  params.set('OCREngine', '2');
+  params.set('base64Image', `data:${mimeType};base64,${buffer.toString('base64')}`);
+
+  try {
+    const response = await fetch(OCR_SPACE_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        apikey: apiKey,
+      },
+      body: params,
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      console.error('OCR.space error response:', message);
+      return {
+        ok: false,
+        text: '',
+        warning: 'Резервный сервис OCR вернул ошибку',
+      };
+    }
+
+    const payload = await response.json();
+    if (payload?.IsErroredOnProcessing) {
+      const errors = []
+        .concat(payload?.ErrorMessage || [])
+        .concat(payload?.ErrorDetails || [])
+        .filter(Boolean)
+        .join('; ');
+      return {
+        ok: false,
+        text: '',
+        warning: errors || 'Резервный сервис OCR не смог обработать изображение',
+      };
+    }
+
+    const parsedText = (payload?.ParsedResults || [])
+      .map((item) => item?.ParsedText || '')
+      .join('\n')
+      .trim();
+
+    if (!parsedText) {
+      return {
+        ok: false,
+        text: '',
+        warning: 'Резервный сервис OCR не распознал текст',
+      };
+    }
+
+    return {
+      ok: true,
+      text: parsedText,
+      warning: null,
+    };
+  } catch (error) {
+    console.error('OCR.space request failed:', error);
+    return {
+      ok: false,
+      text: '',
+      warning: 'Не удалось подключиться к резервному сервису OCR',
+    };
+  }
+}
+
+function pushWarning(list, message) {
+  if (!message) {
+    return;
+  }
+  if (!Array.isArray(list)) {
+    return;
+  }
+  if (!list.includes(message)) {
+    list.push(message);
+  }
+}
+
+function mergeWarnings(...lists) {
+  const merged = [];
+  const seen = new Set();
+
+  lists.forEach((list) => {
+    if (!Array.isArray(list)) {
+      return;
+    }
+    list.forEach((item) => {
+      if (!item || seen.has(item)) {
+        return;
+      }
+      seen.add(item);
+      merged.push(item);
+    });
   });
 
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`Ошибка OCR: ${message}`);
-  }
-
-  const payload = await response.json();
-  const annotation = payload.responses?.[0];
-  const text = annotation?.fullTextAnnotation?.text
-    || annotation?.textAnnotations?.[0]?.description
-    || '';
-  return text.trim();
+  return merged;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add a resilient OCR pipeline that falls back to OCR.space when Google Vision is unavailable and surfaces warnings without failing uploads
- document the optional `OCR_SPACE_API_KEY` configuration for the new fallback service

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d05246175883239daef1e9add6716f